### PR TITLE
docs: standardize multi-module documentation and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,27 @@
+name: Bug report
+description: Report a bug in one of the modules
+labels: [bug]
+body:
+  - type: input
+    id: module
+    attributes:
+      label: Affected module
+      placeholder: e.g., crudapp, SpringSecurityJWT
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs/errors

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,21 @@
+name: Feature request
+description: Suggest an enhancement for a module
+labels: [enhancement]
+body:
+  - type: input
+    id: module
+    attributes:
+      label: Target module
+      placeholder: e.g., spring-boot-mongodb
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Developer/user impact

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Module(s) changed
+
+<!-- e.g., SpringSecurityJWT, crudapp, crud-ui -->
+
+## Summary
+
+## Validation
+
+- [ ] Module builds/tests pass locally
+- [ ] README/docs updated if setup/behavior changed
+- [ ] No secrets added
+
+## Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this repository should be documented here.
+
+## [Unreleased]
+
+### Added
+- Standardized root-level documentation and contribution templates.
+
+### Changed
+- Clarified multi-module run/test workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+Thanks for your interest in contributing.
+
+## Scope
+
+This repository is a collection of independent examples. Keep PRs focused to one module when possible.
+
+## Setup
+
+- Java + Maven for backend modules
+- Node.js for `crud-ui`
+
+## PR expectations
+
+- Include module(s) changed in PR title/description
+- Add/update docs for behavior changes
+- Run relevant checks before submitting
+
+Examples:
+
+```bash
+# For a Maven module
+mvn test
+
+# For wrapper-based module
+./mvnw test
+
+# For frontend
+cd crud-ui && npm test
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,158 @@
-# SpringBoot & ReactJS Applications
+# SpringBoot Collections
 
+A collection of Spring Boot and related full-stack sample projects covering security, CRUD APIs, MongoDB, Eureka service discovery, AWS Lambda deployment, and React UI integration.
+
+## Overview
+
+This repository groups multiple independent examples:
+
+- **SpringSecurityJWT** – JWT auth sample
+- **SpringSecurityApp** – role-based authorization sample
+- **crudapp** – Spring Boot CRUD backend
+- **crud-ui** – React frontend for CRUD flows
+- **spring-boot-mongodb** – MongoDB query examples
+- **EurekhaHelloWorld** – Eureka producer/consumer sample
+- **aws-lambda-springboot-api-main** – Spring Boot packaged for AWS Lambda/API Gateway
+
+## Architecture / Stack
+
+- Java + Spring Boot (multiple modules)
+- Spring Security (JWT + role-based auth)
+- MongoDB (for selected demos)
+- React (for `crud-ui`)
+- Maven / Maven Wrapper
+
+```mermaid
+flowchart TD
+  A[Collection Repo] --> B[Security Samples]
+  A --> C[CRUD Samples]
+  A --> D[Cloud Samples]
+  B --> B1[SpringSecurityJWT]
+  B --> B2[SpringSecurityApp]
+  C --> C1[crudapp API]
+  C --> C2[crud-ui React]
+  C --> C3[spring-boot-mongodb]
+  D --> D1[Eureka Producer/Consumer]
+  D --> D2[AWS Lambda SpringBoot]
+```
+
+## Quickstart
+
+### Prerequisites
+
+- Java 17+ (some modules may work on older versions, but 17+ is recommended)
+- Maven 3.8+
+- Node.js 18+ (for `crud-ui`)
+- MongoDB (for modules that require it)
+
+## Environment Variables
+
+No single `.env` governs the whole monorepo.
+
+Common runtime configuration is handled with `application.properties`/`application.yml` inside each module.
+For cloud modules, supply credentials via your deployment environment (not committed files).
+
+## Run
+
+Run modules independently from their own directories.
+
+### Example: SpringSecurityJWT
+
+```bash
+cd SpringSecurityJWT
+./mvnw spring-boot:run
+```
+
+### Example: crudapp backend
+
+```bash
+cd crudapp
+mvn spring-boot:run
+```
+
+### Example: crud-ui frontend
+
+```bash
+cd crud-ui
+npm install
+npm start
+```
+
+## Test
+
+Per module:
+
+```bash
+# Maven-based modules
+mvn test
+
+# Wrapper-based modules
+./mvnw test
+```
+
+`crud-ui` supports React scripts test command where applicable:
+
+```bash
+cd crud-ui
+npm test
+```
+
+## Deployment
+
+- **AWS Lambda module:** see `aws-lambda-springboot-api-main/README.md`
+- **Other modules:** package JAR and deploy as standard Spring Boot apps
+
+```bash
+mvn clean package
+java -jar target/*.jar
+```
+
+## API Snippets (Representative)
+
+From `crudapp`:
+
+- `GET /users`
+- `GET /users/{name}`
+- `POST /load`
+- `GET /delete/{name}`
+
+Request (`POST /load`):
+
+```json
+{
+  "name": "Jane",
+  "email": "jane@example.com"
+}
+```
+
+From `SpringSecurityJWT`:
+
+- `GET /api/v1/awt`
+- `POST /api/v1/awt/auth`
+
+Request (`POST /api/v1/awt/auth`):
+
+```json
+{
+  "username": "user",
+  "password": "password"
+}
+```
+
+Response: JWT token string.
+
+## Troubleshooting
+
+- **Port conflicts**: multiple apps default to 8080; change `server.port` per module.
+- **Mongo connection issues**: verify local MongoDB is running and connection URI is correct.
+- **Maven wrapper permission denied**: run `chmod +x mvnw`.
+- **Dependency mismatches**: run `mvn -U clean install`.
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md).
+
+## License
+
+No `LICENSE` file is currently present in this repository.
+To avoid assuming legal intent, this docs update does not add one.


### PR DESCRIPTION
This PR standardizes docs for the SpringBoot collections monorepo:

- Replaced minimal root README with module-aware onboarding
- Added CONTRIBUTING and CHANGELOG guidance
- Added issue templates + PR template
- Included representative API snippets from existing controllers

Note: LICENSE file is currently missing in this repository. I did not add one to avoid assuming legal intent.